### PR TITLE
Add binaries to releases

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,0 +1,79 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Linux
+          - goos: linux
+            goarch: amd64
+            output_name: grab-linux-amd64
+          - goos: linux
+            goarch: arm64
+            output_name: grab-linux-arm64
+          # macOS
+          - goos: darwin
+            goarch: amd64
+            output_name: grab-darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            output_name: grab-darwin-arm64
+          # Windows
+          - goos: windows
+            goarch: amd64
+            output_name: grab-windows-amd64.exe
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          
+          go build \
+            -ldflags="-X 'main.version=${VERSION}' -X 'main.commit=${COMMIT}' -X 'main.date=${DATE}'" \
+            -o ${{ matrix.output_name }} \
+            .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.output_name }}
+          path: ${{ matrix.output_name }}
+
+  upload:
+    name: Upload Binaries to Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: binaries
+
+      - name: Upload binaries to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: binaries/**/*


### PR DESCRIPTION
Release automation:

* Added a new workflow file `.github/workflows/release-binaries.yaml` that triggers on GitHub release publication, builds binaries for Linux, macOS, and Windows (amd64 and arm64), and uploads them as release assets.

Similar to:
- https://github.com/sebrandon1/ocp-doc-checker/pull/6
- https://github.com/sebrandon1/yaml-to-readme/pull/33
- https://github.com/sebrandon1/go-dci/pull/51
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2208
- https://github.com/sebrandon1/jiracrawler/pull/15
- https://github.com/sebrandon1/go-quay/pull/40
- https://github.com/redhat-best-practices-for-k8s/perfdive/pull/12