### PR TITLE
build: Downgrade go requirement to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/grab
 
-go 1.25
+go 1.24
 
 require github.com/spf13/cobra v1.10.1
 


### PR DESCRIPTION
go 1.24 is still supported by the go team, and 1.25 is too new for many
usecases. For example, it’s not available in the latest fedora stable
release (f42), or in RHEL.

This PR switches go to 1.24, I’ve tested that this does not cause build
failures.