### PR TITLE
Add CLAUDE.md for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A minimal Go CLI and library for downloading files from the internet, inspired by cURL and wget. Supports concurrent downloads, progress tracking, and hash computation.
+
+## Common Commands
+
+### Build
+```bash
+make build
+```
+
+### Run
+```bash
+# Download a file
+./grab download https://example.com/file.zip
+
+# Download multiple files
+./grab download https://example.com/file1.zip https://example.com/file2.zip
+
+# Verbose mode with progress
+./grab download -v https://example.com/file.zip
+```
+
+### Test
+```bash
+go test ./...
+make test
+```
+
+## Architecture
+
+- **`cmd/`** - CLI command implementations using Cobra
+- **`lib/`** - Core download library with hash computation
+- **`main.go`** - Application entry point
+
+## Features
+
+- Download files from URLs to local directory
+- Automatic filename detection from Content-Disposition headers
+- Concurrent multi-file downloads
+- Real-time progress tracking (verbose mode)
+- Built-in hash computation (MD5, SHA1, SHA256)
+- Usable as Go library or standalone CLI
+
+## Library Usage
+
+```go
+import "github.com/sebrandon1/grab/lib"
+
+client := lib.NewClient()
+resp, err := client.Do(lib.NewRequest("", "https://example.com/file.zip"))
+```
+
+## Requirements
+
+- Go 1.21+
+
+## Code Style
+
+- Follow standard Go conventions
+- Use `go fmt` before committing
+- Run `golangci-lint` for linting


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md file to provide guidance for Claude Code AI assistant
- Documents build commands, architecture, features, and library usage

## Test plan
- [x] File created and follows project conventions
- [ ] Review content for accuracy

## Related PRs
This is part of a batch update adding CLAUDE.md to all public repositories:

| Repository | PR |
|------------|-----|
| compliance-scripts | https://github.com/sebrandon1/compliance-scripts/pull/45 ✅ |
| OpenStack_Shortcuts | https://github.com/sebrandon1/OpenStack_Shortcuts/pull/1 |
| testapp | https://github.com/sebrandon1/testapp/pull/1 |
| yaml-to-readme | https://github.com/sebrandon1/yaml-to-readme/pull/70 |
| ztp-scripts | https://github.com/sebrandon1/ztp-scripts/pull/1 |
| mirrorbot | https://github.com/sebrandon1/mirrorbot/pull/17 |
| go-dci | https://github.com/sebrandon1/go-dci/pull/82 |
| ocp-doc-checker | https://github.com/sebrandon1/ocp-doc-checker/pull/38 |
| jiracrawler | https://github.com/sebrandon1/jiracrawler/pull/36 |
| go-quay | https://github.com/sebrandon1/go-quay/pull/67 |
| CryptoPrices | https://github.com/sebrandon1/CryptoPrices/pull/1 |
| cert-manager-scripts | https://github.com/sebrandon1/cert-manager-scripts/pull/10 |
| grab | https://github.com/sebrandon1/grab/pull/25 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)