### PR TITLE
docs: simplify README by extracting content to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,132 +9,59 @@ A minimal Go CLI and library for downloading files from the internet, inspired b
 
 ## Features
 
-- Download files from URLs to your local directory
-- Automatic filename detection from Content-Disposition headers or URL paths
-- Download multiple files concurrently
+- Download files from URLs with automatic filename detection
+- Concurrent multi-file downloads
 - Real-time progress tracking with verbose mode
 - Built-in file hash computation (MD5, SHA1, SHA256)
-- Simple, modern CLI with `grab download [url]...`
 - Usable as a Go library or standalone binary
 
-## Install
+## Quick Start
 
-### Option 1: Download Pre-built Binaries (Recommended)
-
-Download the latest release for your platform from the [Releases page](https://github.com/sebrandon1/grab/releases):
-
-**Linux (x86_64):**
 ```bash
-curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-linux-amd64 -o grab
-chmod +x grab
-```
-
-**macOS (Intel):**
-```bash
-curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-darwin-amd64 -o grab
-chmod +x grab
-```
-
-**macOS (Apple Silicon):**
-```bash
+# Install (macOS Apple Silicon — see docs/installation.md for all platforms)
 curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-darwin-arm64 -o grab
 chmod +x grab
+
+# Download a file
+grab download https://example.com/file.tar.gz
+
+# Download multiple files concurrently with progress
+grab download -v https://example.com/a.tar.gz https://example.com/b.tar.gz
+
+# Verify file integrity
+grab hash file.tar.gz --type sha256
 ```
 
-**Windows:**
-```bash
-curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-windows-amd64.exe -o grab.exe
-```
-
-### Option 2: Build from Source
-
-Requirements: Go 1.24 or newer
-
-```bash
-git clone https://github.com/sebrandon1/grab.git
-cd grab
-make build
-```
-
-This will produce a `grab` binary in the repo root.
-
-## Usage
-
-### CLI
-
-**Download a single file:**
-```bash
-grab download https://github.com/sebrandon1/grab/archive/refs/heads/main.zip
-```
-
-**Download multiple files concurrently:**
-```bash
-grab download https://go.dev/dl/go1.21.5.src.tar.gz https://go.dev/dl/go1.21.4.src.tar.gz
-```
-
-**Download with verbose progress output:**
-```bash
-grab download https://go.dev/dl/go1.21.5.darwin-amd64.tar.gz --verbose
-```
-Example output:
-```
-Downloading: [======================================= ]  99.34% (135728945/136421772 bytes)
-Downloaded: go1.21.5.darwin-amd64.tar.gz (size: 136421772 bytes)
-```
-
-**Download from GitHub releases:**
-```bash
-grab download https://github.com/golang/go/archive/refs/tags/go1.21.5.tar.gz
-```
-
-**Compute file hashes:**
-```bash
-# Download and verify file integrity
-grab download https://github.com/sebrandon1/grab/archive/refs/heads/main.zip
-grab hash main.zip --type sha256
-
-# Different hash algorithms
-grab hash myfile.tar.gz --type md5
-grab hash myfile.tar.gz --type sha1
-```
-
-**Get help:**
-```bash
-grab --help
-grab download --help
-grab hash --help
-```
-
-### As a Go Library
-
-See [lib/README.md](lib/README.md) for full documentation of the public API.
+## Library Usage
 
 ```go
-package main
+import "github.com/sebrandon1/grab/lib"
 
-import (
-	"log"
-	"github.com/sebrandon1/grab/lib"
-	"context"
-)
-
-func main() {
-	urls := []string{
-		"https://github.com/sebrandon1/grab/archive/refs/heads/main.zip",
-		"https://go.dev/dl/go1.21.5.src.tar.gz",
-	}
-	ch, err := lib.DownloadBatch(context.Background(), urls)
-	if err != nil {
-		log.Fatal(err)
-	}
-	for resp := range ch {
-		if resp.Err != nil {
-			log.Printf("Failed: %s (%v)", resp.Filename, resp.Err)
-		} else {
-			log.Printf("Downloaded: %s", resp.Filename)
-		}
-	}
+ch, err := lib.DownloadBatch(context.Background(), urls)
+for resp := range ch {
+    log.Printf("%s: %v", resp.Filename, resp.Err)
 }
+```
+
+See [lib/README.md](lib/README.md) for the full API reference.
+
+## Guides
+
+| Document | Description |
+|---|---|
+| [Installation](docs/installation.md) | Pre-built binaries for all platforms, building from source |
+| [CLI Reference](docs/cli-reference.md) | Commands, flags, and usage examples |
+| [Library API](lib/README.md) | Go library types, functions, and examples |
+| [Contributing](CONTRIBUTING.md) | Code style, testing, and PR guidelines |
+| [Security](SECURITY.md) | Vulnerability reporting policy |
+
+## Development
+
+```bash
+make build          # Build the binary
+make test           # Run tests with coverage
+make lint           # Run golangci-lint
+make vet            # Run go vet
 ```
 
 ## License

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,66 @@
+# CLI Reference
+
+## Download
+
+Download one or more files from URLs.
+
+### Single file
+
+```bash
+grab download https://github.com/sebrandon1/grab/archive/refs/heads/main.zip
+```
+
+### Multiple files (concurrent)
+
+```bash
+grab download https://go.dev/dl/go1.21.5.src.tar.gz https://go.dev/dl/go1.21.4.src.tar.gz
+```
+
+### Verbose progress output
+
+```bash
+grab download https://go.dev/dl/go1.21.5.darwin-amd64.tar.gz --verbose
+```
+
+Example output:
+
+```
+Downloading: [======================================= ]  99.34% (135728945/136421772 bytes)
+Downloaded: go1.21.5.darwin-amd64.tar.gz (size: 136421772 bytes)
+```
+
+### GitHub releases
+
+```bash
+grab download https://github.com/golang/go/archive/refs/tags/go1.21.5.tar.gz
+```
+
+## Hash
+
+Compute file hashes to verify integrity.
+
+```bash
+# SHA-256 (default)
+grab hash myfile.tar.gz --type sha256
+
+# MD5
+grab hash myfile.tar.gz --type md5
+
+# SHA-1
+grab hash myfile.tar.gz --type sha1
+```
+
+### Download and verify workflow
+
+```bash
+grab download https://github.com/sebrandon1/grab/archive/refs/heads/main.zip
+grab hash main.zip --type sha256
+```
+
+## Help
+
+```bash
+grab --help
+grab download --help
+grab hash --help
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,44 @@
+# Installation
+
+## Pre-built Binaries (Recommended)
+
+Download the latest release for your platform from the [Releases page](https://github.com/sebrandon1/grab/releases).
+
+### Linux (x86_64)
+
+```bash
+curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-linux-amd64 -o grab
+chmod +x grab
+```
+
+### macOS (Intel)
+
+```bash
+curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-darwin-amd64 -o grab
+chmod +x grab
+```
+
+### macOS (Apple Silicon)
+
+```bash
+curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-darwin-arm64 -o grab
+chmod +x grab
+```
+
+### Windows
+
+```bash
+curl -L https://github.com/sebrandon1/grab/releases/latest/download/grab-windows-amd64.exe -o grab.exe
+```
+
+## Build from Source
+
+Requirements: Go 1.24 or newer
+
+```bash
+git clone https://github.com/sebrandon1/grab.git
+cd grab
+make build
+```
+
+This will produce a `grab` binary in the repo root.


### PR DESCRIPTION
## Summary

Slims down the README from a 142-line monolith to a 69-line landing page by extracting detailed content into dedicated docs/ files. No content was removed — everything was relocated.

**Before:** 142 lines (README.md)
**After:** 69 lines (README.md) + 44 lines (docs/installation.md) + 66 lines (docs/cli-reference.md)

## Changes

| File | Action | Description |
|---|---|---|
| `README.md` | Rewritten | Concise landing page with overview, quick start, guides table, dev commands |
| `docs/installation.md` | Created | Pre-built binary downloads for all platforms, build from source instructions |
| `docs/cli-reference.md` | Created | Full CLI usage: download, hash, verbose mode, help |

## Guides

| Document | Description |
|---|---|
| [Installation](docs/installation.md) | Pre-built binaries for all platforms, building from source |
| [CLI Reference](docs/cli-reference.md) | Commands, flags, and usage examples |
| [Library API](lib/README.md) | Go library types, functions, and examples |
| [Contributing](CONTRIBUTING.md) | Code style, testing, and PR guidelines |

## Test plan

- [ ] Verify all links in README.md resolve correctly
- [ ] Verify docs/installation.md contains all platform install instructions from original README
- [ ] Verify docs/cli-reference.md contains all CLI examples from original README
- [ ] Verify no content was lost in the extraction
- [ ] Confirm README renders correctly on GitHub

## Related to

- sebrandon1/tls-compliance-operator [#209](https://github.com/sebrandon1/tls-compliance-operator/pull/209)
- sebrandon1/imagecertinfo-operator [#115](https://github.com/sebrandon1/imagecertinfo-operator/pull/115)
- sebrandon1/tls-config-lint [#16](https://github.com/sebrandon1/tls-config-lint/pull/16)
- openshift-kni/olm-annotation-lint [#50](https://github.com/openshift-kni/olm-annotation-lint/pull/50)
- sebrandon1/succulent-cli [#59](https://github.com/sebrandon1/succulent-cli/pull/59)
- sebrandon1/ocp-doc-checker [#55](https://github.com/sebrandon1/ocp-doc-checker/pull/55)
- sebrandon1/go-quay [#111](https://github.com/sebrandon1/go-quay/pull/111)
- sebrandon1/compliance-scripts [#122](https://github.com/sebrandon1/compliance-scripts/pull/122)
- sebrandon1/go-skylight [#175](https://github.com/sebrandon1/go-skylight/pull/175)
- sebrandon1/go-enphase [#22](https://github.com/sebrandon1/go-enphase/pull/22)
- sebrandon1/skylight-bridge [#18](https://github.com/sebrandon1/skylight-bridge/pull/18)
- sebrandon1/ztp-dashboard [#117](https://github.com/sebrandon1/ztp-dashboard/pull/117)
- sebrandon1/bps-operator [#110](https://github.com/sebrandon1/bps-operator/pull/110)
- sebrandon1/yaml-to-readme [#153](https://github.com/sebrandon1/yaml-to-readme/pull/153)
- sebrandon1/jiracrawler [#84](https://github.com/sebrandon1/jiracrawler/pull/84)
- sebrandon1/compliance-operator-dashboard [#121](https://github.com/sebrandon1/compliance-operator-dashboard/pull/121)